### PR TITLE
fix env vars

### DIFF
--- a/incubator/airflow/templates/deployments-flower.yaml
+++ b/incubator/airflow/templates/deployments-flower.yaml
@@ -30,8 +30,9 @@ spec:
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
           imagePullPolicy: {{ .Values.airflow.image.pull_policy }}
           envFrom:
-            - configMapRef:
-                name: "{{ template "airflow.fullname" . }}-env"
+          - configMapRef:
+              name: "{{ template "airflow.fullname" . }}-env"
+          env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -42,13 +43,16 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
+            - name: REDIS_USER
+              valueFrom:
+                secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
-                  key: RedisPassword
+                  key: redisPassword
           ports:
             - name: flower
               containerPort: 5555

--- a/incubator/airflow/templates/deployments-flower.yaml
+++ b/incubator/airflow/templates/deployments-flower.yaml
@@ -43,11 +43,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-            - name: REDIS_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
-                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -42,11 +42,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-            - name: REDIS_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
-                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -29,8 +29,9 @@ spec:
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
           imagePullPolicy: {{ .Values.airflow.image.pull_policy}}
           envFrom:
-            - configMapRef:
-                name: "{{ template "airflow.fullname" . }}-env"
+          - configMapRef:
+              name: "{{ template "airflow.fullname" . }}-env"
+          env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -41,7 +42,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-                name: {{ template "airflow.fullname" . }}
+            - name: REDIS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "airflow.fullname" . }}
+                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/incubator/airflow/templates/deployments-web.yaml
+++ b/incubator/airflow/templates/deployments-web.yaml
@@ -47,11 +47,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-            - name: REDIS_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
-                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/incubator/airflow/templates/deployments-web.yaml
+++ b/incubator/airflow/templates/deployments-web.yaml
@@ -34,8 +34,9 @@ spec:
               containerPort: 8080
               protocol: TCP
           envFrom:
-            - configMapRef:
-                name: "{{ template "airflow.fullname" . }}-env"
+          - configMapRef:
+              name: "{{ template "airflow.fullname" . }}-env"
+          env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -46,12 +47,16 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-                name: {{ template "airflow.fullname" . }}
+            - name: REDIS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "airflow.fullname" . }}
+                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
-                  key: RedisPassword
+                  key: redisPassword
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: dags-data

--- a/incubator/airflow/templates/secrets.yaml
+++ b/incubator/airflow/templates/secrets.yaml
@@ -9,7 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  postgresUser: {{ template "airflow.defaultsecret" .Values.postgresql.postgresUser }}
-  postgresPassword: {{ template "airflow.defaultsecret" .Values.postgresql.postgresPassword }}
-  redisUser: {{ template "airflow.defaultsecret" .Values.redis.redisUser }}
-  redisPassword: {{ template "airflow.defaultsecret" .Values.redis.redisPassword }}
+  postgresUser: {{ .Values.postgresql.postgresUser | b64enc | quote }}
+  postgresPassword: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  redisPassword: {{ .Values.redis.redisPassword | b64enc | quote }}

--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -34,8 +34,9 @@ spec:
           imagePullPolicy: {{ .Values.airflow.image.pull_policy }}
           image: "{{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}"
           envFrom:
-            - configMapRef:
-                name: "{{ template "airflow.fullname" . }}-env"
+          - configMapRef:
+              name: "{{ template "airflow.fullname" . }}-env"
+          env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -46,12 +47,16 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-                name: {{ template "airflow.fullname" . }}
+            - name: REDIS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "airflow.fullname" . }}
+                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
-                  key: RedisPassword
+                  key: redisPassword
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: dags-data

--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -47,11 +47,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "airflow.fullname" . }}
                   key: postgresPassword
-            - name: REDIS_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
-                  key: redisUser
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Changes:

1. Indentation after envFrom was incorrect, causing some cryptic errors...
2. Env vars from secrets need to be put in 'env' block not 'envFrom'
3. Removed redisUser value, I think it is not used
4. Applied base64 encoding

With this changes, the chart is now working again for me.
However, I have reverted the apiVersion changes locally (extensions/v1beta1 -> extensions/v1), that does not work on our cluster (k8s v1.8.8)


