### PR TITLE
Airflow worker serviceaccount

### DIFF
--- a/incubator/airflow/examples/minikube-values.yaml
+++ b/incubator/airflow/examples/minikube-values.yaml
@@ -12,9 +12,13 @@ airflow:
     AIRFLOW__CORE__LOGGING_LEVEL: DEBUG
     AIRFLOW__CORE__LOAD_EXAMPLES: True
 
-celery:
-  ## Number of celery workers to initialize
-  num_workers: 2
+workers:
+  serviceAccountName: "default"
+  replicas: 1
+
+  celery:
+    # instances per worker
+    instances: 1
 
 ingress:
   enabled: true

--- a/incubator/airflow/templates/NOTES.txt
+++ b/incubator/airflow/templates/NOTES.txt
@@ -3,8 +3,8 @@ Congratulations. You have just deployed Apache Airflow
 1. Get the Artifactory URL by running these commands:
 
    {{- if .Values.ingress.enabled }}
-    - Web UI: http://{{ .Value.ingress.web.host }}{{ .Value.ingress.web.path }}
-    - Flower: http://{{ .Value.ingress.flower.host }}{{ .Value.ingress.flower.path }}
+    - Web UI: http://{{ .Values.ingress.web.host }}{{ .Values.ingress.web.path }}
+    - Flower: http://{{ .Values.ingress.flower.host }}{{ .Values.ingress.flower.path }}
 
    {{- else if contains "NodePort" .Values.airflow.service.type }}
    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "airflow.fullname" . }})

--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   serviceName: "{{ template "airflow.fullname" . }}-workers"
+  serviceAccountName: {{ .Values.workers.serviceAccountName }}
   updateStrategy:
     type: RollingUpdate
   ## Use experimental burst mode for faster StatefulSet scaling

--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -18,7 +18,7 @@ spec:
   ## Use experimental burst mode for faster StatefulSet scaling
   ##   https://github.com/kubernetes/kubernetes/commit/c2c5051adf096ffd48bf1dcf5b11cb47e464ecdd
   podManagementPolicy: Parallel
-  replicas: {{ .Values.celery.num_workers }}
+  replicas: {{ .Values.workers.celery.instances }}
   selector:
     matchLabels:
       app: {{ template "airflow.name" . }}-worker

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -61,14 +61,12 @@ airflow:
     maxUnavailable: 1
 
 workers:
-    serviceAccountName: "default"
+  serviceAccountName: "default"
+  replicas: 1
 
-##
-## Configuration for celery workers
-celery:
-  ##
-  ## Number of celery workers to initialize
-  num_workers: 1
+  celery:
+    # instances per worker
+    instances: 1
 
 
 ##

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -60,6 +60,8 @@ airflow:
   pod_disruption_budget:
     maxUnavailable: 1
 
+workers:
+    serviceAccountName: "default"
 
 ##
 ## Configuration for celery workers


### PR DESCRIPTION
This PR adds a configurable serviceAccount to the worker Pods.

This is necesarry if you have RBAC enabled on your cluster and you want to do certain things in the cluster, like launching new Pods. E.g. if you want to launch a Spark job from the worker.