### PR TITLE
Fix a templating typo

### DIFF
--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -64,4 +64,4 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (include "airflow.fullname" .) }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}


### PR DESCRIPTION
There's a small typo in the template which I noticed when I added a custom Secrets volume for the scheduler. The YAML config accidentally works if the typo is on the last line. :)

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
