### PR TITLE
Parameterize the -p argument to the scheduler command

### DIFF
--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -56,7 +56,10 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.airflow.dag_path }}
           {{- end }}
-          args: ["scheduler", "-n", "{{ .Values.airflow.scheduler_num_runs }}" {{- if .Values.airflow.scheduler_do_pickle }} , "-p" {{- end }}]
+          args: ["scheduler",
+            "-n", "{{ .Values.airflow.scheduler_num_runs }}",
+            {{- if .Values.airflow.scheduler_do_pickle }} "-p" {{- end }}
+          ]
       volumes:
         - name: dags-data
         {{- if .Values.persistence.enabled }}

--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -56,7 +56,7 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.airflow.dag_path }}
           {{- end }}
-          args: ["scheduler", "-n", "{{ .Values.airflow.scheduler_num_runs }}" {{- if .Values.scheduler_do_pickle }} , "-p" {{- end }}]
+          args: ["scheduler", "-n", "{{ .Values.airflow.scheduler_num_runs }}" {{- if .Values.airflow.scheduler_do_pickle }} , "-p" {{- end }}]
       volumes:
         - name: dags-data
         {{- if .Values.persistence.enabled }}

--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -56,7 +56,7 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.airflow.dag_path }}
           {{- end }}
-          args: ["scheduler", "-n", "{{ .Values.airflow.scheduler_num_runs }}", "-p"]
+          args: ["scheduler", "-n", "{{ .Values.airflow.scheduler_num_runs }}" {{- if .Values.scheduler_do_pickle }} , "-p" {{- end }}]
       volumes:
         - name: dags-data
         {{- if .Values.persistence.enabled }}

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -44,6 +44,12 @@ airflow:
   ##   1 will have the scheduler quit after each refresh, but kubernetes will restart it
   scheduler_num_runs: "-1"
   ##
+  ## Set scheduler_do_pickle to toggle whether to have the scheduler
+  ## attempt to pickle the DAG object to send over to the workers,
+  ## instead of letting workers run their version of the code.
+  ## See the Airflow documentation for the --do_pickle argument: https://airflow.apache.org/cli.html#scheduler
+  scheduler_do_pickle: true
+  ##
   ## how many replicas for web server
   ## For the moment, we recommend to leave this value to 1, since the webserver instance performs
   ## the 'initdb' operation, starting more replicas will cause all the web containers to execute


### PR DESCRIPTION
I was running into trouble when the scheduler was pickling my DAGs, specifically when the DAG had a `PythonOperator` task. The only way to get around it seemed to be to avoid passing in the `-p` argument to the scheduler. This just parameterizes that argument, toggling its usage via the values file.

Let me know if you have any questions about the issue I was experiencing or anything else; I'm happy to provide more detail if needed.

Thanks for putting this together!