### PR TITLE
Headless service name should match statefulset serviceName

### DIFF
--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceName: "{{ template "airflow.fullname" . }}-workers"
+  serviceName: "{{ template "airflow.fullname" . }}-worker"
   updateStrategy:
     type: RollingUpdate
   ## Use experimental burst mode for faster StatefulSet scaling


### PR DESCRIPTION
I had issues where Airflow could not find the log files, so I started looking into it and concluded that everything was working (hostname correct in task instance, could retrieve logs from worker internally) except for the DNS resolution.

This commit changes the StatefulSet serviceName suffix to *-worker* instead of *-workers*, so that it matches the Service name.

Other people have had this problem:  [kubernetes issue #57671](https://github.com/kubernetes/kubernetes/issues/57671), [kubernetes issue #45779](https://github.com/kubernetes/kubernetes/issues/45779).

Now all is fine, the logs are shown.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
