### PR TITLE
airflow: Add support for ingress TLS termination

### DIFF
--- a/incubator/airflow/README.md
+++ b/incubator/airflow/README.md
@@ -176,10 +176,14 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `ingres.web.host`                          | hostname for the webserver ui                           | ""                                                         |
 | `ingres.web.path`                          | path of the werbserver ui (read `values.yaml`)          | ``                                                         |
 | `ingres.web.annotations`                   | annotations for the web ui ingress                      | `{}`                                                       |
+| `ingres.web.tls.enabled`                   | enables TLS termination at the ingress                  | `false`                                                    |
+| `ingres.web.tls.secretName`                | name of the secret containing the TLS certificate & key | ``                                                         |
 | `ingres.flower.host`                       | hostname for the flower ui                              | ""                                                         |
 | `ingres.flower.path`                       | path of the flower ui (read `values.yaml`)              | ``                                                         |
 | `ingres.flower.liveness_path`              | path to the liveness probe (read `values.yaml`)         | `/`                                                        |
 | `ingres.flower.annotations`                | annotations for the web ui ingress                      | `{}`                                                       |
+| `ingres.flower.tls.enabled`                | enables TLS termination at the ingress                  | `false`                                                    |
+| `ingres.flower.tls.secretName`             | name of the secret containing the TLS certificate & key | ``                                                         |
 | `persistance.enabled`                      | enable persistance storage for DAGs                     | `false`                                                    |
 | `persistance.existingClaim`                | if using an existing claim, specify the name here       | `nil`                                                      |
 | `persistance.storageClass`                 | Persistent Volume Storage Class                         | (undefined)                                                |

--- a/incubator/airflow/templates/ingresses.yaml
+++ b/incubator/airflow/templates/ingresses.yaml
@@ -13,6 +13,12 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{- if .Values.ingress.web.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.web.host }}
+      secretName: {{ .Values.ingress.web.tls.secretName }}
+{{- end }}
   rules:
     - http:
         paths:
@@ -36,6 +42,12 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{- if .Values.ingress.flower.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.flower.host }}
+      secretName: {{ .Values.ingress.flower.tls.secretName }}
+{{- end }}
   rules:
     - http:
         paths:

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -135,6 +135,12 @@ ingress:
       ## Example for Traefik:
       # traefik.frontend.rule.type: PathPrefix
       # kubernetes.io/ingress.class: traefik
+    tls:
+      ## Set to "true" to enable TLS termination at the ingress
+      enabled: false
+      ## If enabled, set "secretName" to the secret containing the TLS private key and certificate
+      ## Example:
+      ## secretName: example-com-crt
   ##
   ## Configure the flower endpoind
   flower:
@@ -190,6 +196,12 @@ ingress:
       # traefik.frontend.rule.type: PathPrefix       ## Flower >= Jan 2018
       # traefik.frontend.rule.type: PathPrefixStrip  ## Flower < Jan 2018
       # kubernetes.io/ingress.class: traefik
+    tls:
+      ## Set to "true" to enable TLS termination at the ingress
+      enabled: false
+      ## If enabled, set "secretName" to the secret containing the TLS private key and certificate
+      ## Example:
+      ## secretName: example-com-crt
 
 
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Support for TLS termination at web and flower ingresses.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:
