### PR TITLE
RBAC config and executor override

### DIFF
--- a/incubator/airflow/Chart.yaml
+++ b/incubator/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.8.0
-appVersion: 1.9.0
+version: 0.9.0
+appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/
 maintainers:

--- a/incubator/airflow/README.md
+++ b/incubator/airflow/README.md
@@ -204,16 +204,17 @@ The following table lists the configurable parameters of the Airflow chart and t
 |------------------------------------------|---------------------------------------------------------|---------------------------|
 | `airflow.fernetKey`                      | Ferney key (see `values.yaml` for example)              | (auto generated)          |
 | `airflow.service.type`                   | services type                                           | `ClusterIP`               |
+| `airflow.executor`                       | the executor to run                                     | `Celery`                  |
 | `airflow.initRetryLoop`                  | max number of retries during container init             |                           |
 | `airflow.image.repository`               | Airflow docker image                                    | `puckel/docker-airflow`   |
-| `airflow.image.tag`                      | Airflow docker tag                                      | `1.9.0-5`                 |
+| `airflow.image.tag`                      | Airflow docker tag                                      | `1.10.0-4`                |
 | `airflow.image.pullPolicy`               | Image pull policy                                       | `IfNotPresent`            |
 | `airflow.image.pullSecret`               | Image pull secret                                       |                           |
 | `airflow.schedulerNumRuns`               | -1 to loop indefinitively, 1 to restart after each exec |                           |
 | `airflow.webReplicas`                    | how many replicas for web server                        | `1`                       |
 | `airflow.config`                         | custom airflow configuration env variables              | `{}`                      |
 | `airflow.podDisruptionBudget`            | control pod disruption budget                           | `{'maxUnavailable': 1}`   |
-| `workers.serviceAccountName`             | worker service account                                  | `default`                 |
+| `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |
 | `workers.resources`                      | custom resource configuration for worker pod            | `{}`                      |
 | `workers.celery.instances`               | number of parallel celery tasks per worker              | `1`                       |
@@ -243,6 +244,9 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `dags.initContainer.installRequirements` | auto install requirements.txt deps                      | `true`                    |
 | `dags.git.url`                           | url to clone the git repository                         | nil                       |
 | `dags.git.ref`                           | branch name, tag or sha1 to reset to                    | `master`                  |
+| `rbac.create`                            | create RBAC resources                                   | `true`                    |
+| `serviceAccount.create`                  | create a service account                                | `true`                    |
+| `serviceAccount.name`                    | the service account name                                | ``                        |
 | `postgres.enabled`                       | create a postgres server                                | `true`                    |
 | `postgres.uri`                           | full URL to custom postgres setup                       | (undefined)               |
 | `postgres.postgresUser`                  | PostgreSQL User                                         | `postgres`                |

--- a/incubator/airflow/README.md
+++ b/incubator/airflow/README.md
@@ -249,6 +249,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `serviceAccount.name`                    | the service account name                                | ``                        |
 | `postgres.enabled`                       | create a postgres server                                | `true`                    |
 | `postgres.uri`                           | full URL to custom postgres setup                       | (undefined)               |
+| `postgres.portgresHost`                  | PostgreSQL Hostname                                     | (undefined)               |
 | `postgres.postgresUser`                  | PostgreSQL User                                         | `postgres`                |
 | `postgres.postgresPassword`              | PostgreSQL Password                                     | `airflow`                 |
 | `postgres.postgresDatabase`              | PostgreSQL Database name                                | `airflow`                 |

--- a/incubator/airflow/examples/minikube-values.yaml
+++ b/incubator/airflow/examples/minikube-values.yaml
@@ -12,7 +12,6 @@ airflow:
     AIRFLOW__CORE__LOAD_EXAMPLES: True
 
 workers:
-  serviceAccountName: "default"
   replicas: 1
   celery:
     instances: 1

--- a/incubator/airflow/templates/_helpers.tpl
+++ b/incubator/airflow/templates/_helpers.tpl
@@ -33,12 +33,16 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Create a default fully qualified postgresql name.
+Create a default fully qualified postgresql name or use the `postgresHost` value if defined.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "airflow.postgresql.fullname" -}}
-{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.postgresql.postgresHost }}
+    {{- printf "%s" .Values.postgresql.postgresHost -}}
+{{- else }}
+    {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/incubator/airflow/templates/_helpers.tpl
+++ b/incubator/airflow/templates/_helpers.tpl
@@ -22,6 +22,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "airflow.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "airflow.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified postgresql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/incubator/airflow/templates/configmap-airflow.yaml
+++ b/incubator/airflow/templates/configmap-airflow.yaml
@@ -16,7 +16,7 @@ data:
   FLOWER_PORT: "5555"
   # Configure puckel's docker-airflow entrypoint
   # 1.9.0-2
-  EXECUTOR: "Celery"
+  EXECUTOR: "{{ .Values.airflow.executor }}"
   FERNET_KEY: "{{ .Values.airflow.fernetKey }}"
   DO_WAIT_INITDB: "false"
   ## Custom Airflow settings

--- a/incubator/airflow/templates/deployments-flower.yaml
+++ b/incubator/airflow/templates/deployments-flower.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workers.enabled -}}
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -70,3 +71,4 @@ spec:
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 5
+{{- end }}

--- a/incubator/airflow/templates/deployments-scheduler.yaml
+++ b/incubator/airflow/templates/deployments-scheduler.yaml
@@ -34,6 +34,7 @@ spec:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
       restartPolicy: Always
+      serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone

--- a/incubator/airflow/templates/ingress-flower.yaml
+++ b/incubator/airflow/templates/ingress-flower.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and (.Values.workers.enabled)  (.Values.ingress.enabled) -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/incubator/airflow/templates/role-binding.yaml
+++ b/incubator/airflow/templates/role-binding.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "airflow.fullname" . }}
+  labels:
+    app: {{ template "airflow.name" . }}
+    chart: {{ template "airflow.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "airflow.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "airflow.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/incubator/airflow/templates/role.yaml
+++ b/incubator/airflow/templates/role.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "airflow.fullname" . }}
+  labels:
+    app: {{ template "airflow.name" . }}
+    chart: {{ template "airflow.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["create", "get", "delete", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - "pods/log"
+  verbs: ["get", "list"]
+{{ end }}

--- a/incubator/airflow/templates/service-account.yaml
+++ b/incubator/airflow/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "airflow.serviceAccountName" . }}
+  labels:
+    app: {{ template "airflow.name" . }}
+    chart: {{ template "airflow.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{ end }}

--- a/incubator/airflow/templates/service-flower.yaml
+++ b/incubator/airflow/templates/service-flower.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workers.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     - name: flower
       protocol: TCP
       port: 5555
+{{- end }}

--- a/incubator/airflow/templates/service-worker.yaml
+++ b/incubator/airflow/templates/service-worker.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workers.enabled -}}
 # Headless service for stable DNS entries of StatefulSet members.
 apiVersion: v1
 kind: Service
@@ -16,3 +17,4 @@ spec:
   clusterIP: None
   selector:
     app: {{ template "airflow.name" . }}-worker
+{{- end }}

--- a/incubator/airflow/templates/statefulsets-workers.yaml
+++ b/incubator/airflow/templates/statefulsets-workers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workers.enabled -}}
 ## Workers are not in deployment, but in StatefulSet, to allow each worker expose a mini-server
 ## that only serve logs, that will be used by the web server.
 
@@ -41,7 +42,7 @@ spec:
       {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
-      serviceAccountName: {{ .Values.workers.serviceAccountName }}
+      serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone
@@ -149,3 +150,4 @@ spec:
             name: {{ template "airflow.fullname" . }}-git-clone
             defaultMode: 0755
         {{- end }}
+{{- end }}

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -13,6 +13,10 @@ airflow:
   service:
     type: ClusterIP
   ##
+  ## The executor to use.
+  ##
+  exeuctor: Celery
+  ##
   ## set the max number of retries during container initialization
   initRetryLoop:
   ##
@@ -29,7 +33,7 @@ airflow:
     repository: puckel/docker-airflow
     ##
     ## image tag
-    tag: 1.9.0-4
+    tag: 1.10.0-4
     ##
     ## Image pull policy
     ## values: Always or IfNotPresent
@@ -80,9 +84,7 @@ airflow:
 ##
 ## Workers configuration
 workers:
-  ##
-  ## Service account name
-  serviceAccountName: "default"
+  enabled: true
   ##
   ## Number of workers pod to launch
   replicas: 1
@@ -266,6 +268,23 @@ dags:
     enabled: false
     ## install requirements.txt dependencies automatically
     installRequirements: true
+
+##
+##  Enable RBAC
+rbac:
+  ##
+  ## Specifies whether RBAC resources should be created
+  create: true
+
+##
+## Create or use ServiceAccount
+serviceAccount:
+  ##
+  ## Specifies whether a ServiceAccount should be created
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
 
 ##
 ## Configuration values for the postgresql dependency.

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -299,6 +299,8 @@ postgresql:
   ## e.g. postgres://airflow:changeme@my-postgres.com:5432/airflow?sslmode=disable
   # uri:
   ##
+  ## PostgreSQL hostname
+  ## postgresHost:
   ##
   ## PostgreSQL port
   postgresPort: 5432

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -229,7 +229,7 @@ persistence:
   enabled: false
   ##
   ## Existing claim to use
-  existingClaim: nil
+  # existingClaim: nil
   ##
   ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>


### PR DESCRIPTION
This PR adds support or changes for:

- RBAC setup
- Ability to disable the redis+celery systems and allow for setting an alternative `executor`, such as the kubernetes executor
- Wire up the `serviceAccountName` to additional resources
- Update to latest airflow release

These changes allowed me to get up and running with the KubernetesExecutor in a minikube environment (and I expect in an actual cluster as well) with the steps outlaid here: https://gist.github.com/kppullin/54d07f557c7c64c321786d6ed40b46e1