### PR TITLE
chore/cleanup: fix spelling

### DIFF
--- a/incubator/airflow/README.md
+++ b/incubator/airflow/README.md
@@ -28,7 +28,7 @@ helm delete  --purge "airflow"
 
 The Chart provides ingress configuration to allow customization the installation by adapting
 the `values.yaml` depending on your setup.
-Please read the comments in the `value.yaml` file for more detail on how to configure your reverse
+Please read the comments in the `values.yaml` file for more details on how to configure your reverse
 proxy or load balancer.
 
 ### Chart Prefix
@@ -55,14 +55,14 @@ airflow has been updated to its current HEAD. You can use the following image:
 `stibbons31/docker-airflow-dev:2.0dev`. It is rebase regularly on top of the `puckel/docker-airflow`
 image.
 
-Please also note than Airflow UI and Flower do not behave the same:
+Please also note that the Airflow UI and Flower do not behave the same:
 
-- Airflow Web UI behave transparently, to configure it one just need to specify the
+- Airflow Web UI behaves transparently, to configure it one just needs to specify the
   `ingress.web.path` value.
-- Flower cannot handle this scheme directly and requires to use an URL rewrite mechanism in front
+- Flower cannot handle this scheme directly and requires a URL rewrite mechanism in front
   of it. In short, it is able to generate the right URLs in the returned HTML file but cannot
   respond to these URL. It is commonly found in software that wasn't intended to work under
-  something else than a root URL or localhost port. To use it, see the `value.yaml` in detail on how
+  something else than a root URL or localhost port. To use it, see the `values.yaml` for how
   to configure your ingress controller to rewrite the URL (or "strip" the prefix path).
 
   Note: unreleased Flower (as of June 2018) does not need the prefix strip feature anymore. It is

--- a/incubator/airflow/templates/configmap-airflow.yaml
+++ b/incubator/airflow/templates/configmap-airflow.yaml
@@ -15,7 +15,6 @@ data:
   ## Flower PORT
   FLOWER_PORT: "5555"
   # Configure puckel's docker-airflow entrypoint
-  # 1.9.0-2
   EXECUTOR: "{{ .Values.airflow.executor }}"
   FERNET_KEY: "{{ .Values.airflow.fernetKey }}"
   DO_WAIT_INITDB: "false"

--- a/incubator/airflow/values.yaml
+++ b/incubator/airflow/values.yaml
@@ -5,7 +5,7 @@
 ## common settings and setting for the webserver
 airflow:
   ##
-  ## You will need to define your frenet key:
+  ## You will need to define your fernet key:
   ## Generate fernetKey with:
   ##    python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ## fernetKey: ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD
@@ -15,7 +15,7 @@ airflow:
   ##
   ## The executor to use.
   ##
-  exeuctor: Celery
+  executor: Celery
   ##
   ## set the max number of retries during container initialization
   initRetryLoop:
@@ -61,7 +61,7 @@ airflow:
   ## See the Airflow documentation for the --do_pickle argument: https://airflow.apache.org/cli.html#scheduler
   schedulerDoPickle: true
   ##
-  ## how many replicas for web server
+  ## Number of replicas for web server.
   ## For the moment, we recommend to leave this value to 1, since the webserver instance performs
   ## the 'initdb' operation, starting more replicas will cause all the web containers to execute
   ## it, which may cause unwanted issues on the database.
@@ -162,7 +162,7 @@ ingress:
   ## Configure the flower endpoind
   flower:
     ##
-    ## if flower is '/airflow/flower':
+    ## If flower is '/airflow/flower':
     ##  - Flower UI is at 'http://mycompany.com/airflow/flower'
     ## NOTE: you need to have a reverse proxy/load balancer able to do URL rewrite in order to have
     ## flower mounted on other path than root. Flower only does half the job in url prefixing: it


### PR DESCRIPTION
### Change Summary
- fix spelling of `executor` in `values.yaml`
- other spelling and grammar cleanup